### PR TITLE
Fix Tinode initialization error.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tinode-sdk",
-  "version": "0.16.3-rc4",
+  "version": "0.16.3-rc5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/tinode.js
+++ b/src/tinode.js
@@ -1003,19 +1003,23 @@ var Connection = function(host_, apiKey_, transport_, secure_, autoreconnect_) {
   if (transport_ === 'lp') {
     // explicit request to use long polling
     init_lp(this);
+    initialized = true;
   } else if (transport_ === 'ws') {
     // explicit request to use web socket
     // if websockets are not available, horrible things will happen
     init_ws(this);
+    initialized = true;
 
     // Default transport selection
   } else if (typeof window == 'object') {
     if (window['WebSocket']) {
       // Using web sockets -- default.
       init_ws(this);
+      initialized = true;
     } else if (window['XMLHttpRequest']) {
       // The browser has no websockets, using long polling.
       init_lp(this);
+      initialized = true;
     }
   }
 

--- a/src/tinode.js
+++ b/src/tinode.js
@@ -5409,7 +5409,7 @@ var LargeFileHelper = function(tinode) {
   this._apiKey = tinode._apiKey;
   this._authToken = tinode.getAuthToken();
   this._msgId = tinode.getNextUniqueId();
-  this.xhr = XMLHttpRequest();
+  this.xhr = new XMLHttpRequest();
 
   // Promise
   this.toResolve = null;


### PR DESCRIPTION
https://github.com/tinode/tinode-js/commit/18ac7a7e7c1c45622ea705a3538c73eb33b3be5f breaks SDK.

Also handle a syntax error that breaks sending file attachments.