### PR TITLE
fix: add 's' suffix to _processMetaSub following previous change

### DIFF
--- a/src/tinode.js
+++ b/src/tinode.js
@@ -597,7 +597,7 @@ export class Tinode {
               const topic = this.#cacheGet('topic', pkt.ctrl.topic);
               if (topic) {
                 // Trigger topic.onSubsUpdated.
-                topic._processMetaSub([]);
+                topic._processMetaSubs([]);
               }
             }
           }


### PR DESCRIPTION
Hi,
This commit is regarding a missing rename in tinode.js file following the change made in topic.js (commit: https://github.com/tinode/tinode-js/commit/ef312f9d1b030f577d9ff4d5047d24af2fc50383). 
Original Bug was reported on google groups https://groups.google.com/g/tinode/c/ghm7jknaYuY