### PR TITLE
bugfix: #69 should not throw db not intialised error if indexeddb not…

### DIFF
--- a/src/db.js
+++ b/src/db.js
@@ -21,7 +21,7 @@ export default class DB {
   // Instance of IndexDB.
   db = null;
   // Indicator that the cache is disabled.
-  disabled = false;
+  disabled = true;
 
   constructor(onError, logger) {
     this.#onError = onError || this.#onError;


### PR DESCRIPTION
… available

- by defaulting value of disabled variable to true, only when db is available should set disabled:false